### PR TITLE
Add reducer tests; require solutions to be passed into newGame

### DIFF
--- a/src/components/display-rows.test.ts
+++ b/src/components/display-rows.test.ts
@@ -5,7 +5,7 @@ import { computeDisplayRows } from "./display-rows.js";
 
 describe("computeDisplayRows", () => {
   it("new game", () => {
-    const game = newGame();
+    const game = newGame({ solutions: ["CIGAR"] });
     const result = computeDisplayRows(game.gameBoards[0], game);
     expectEqual(result, [
       { rowType: "guessing", currentRow: "" },

--- a/src/game-logic.ts
+++ b/src/game-logic.ts
@@ -46,3 +46,7 @@ export const pickSolution = () => {
   }
   throw new Error("Problem selecting word.");
 };
+
+/** One random solution per board. */
+export const pickSolutions = (numBoards: number): string[] =>
+  Array.from({ length: numBoards }, () => pickSolution());

--- a/src/state/game-states.ts
+++ b/src/state/game-states.ts
@@ -1,24 +1,17 @@
-import { pickSolution } from "../game-logic.js";
 import { GameState, GuessedRow } from "../types.js";
 
 type NewGameParams = {
-  numBoards?: number;
+  /** One solution per board; its length decides how many boards there are. */
+  solutions: string[];
   numGuesses?: number;
-  /**
-   * Solutions to use, by board index. Boards without one get a random word.
-   * Lets tests pin the answers instead of working around Math.random().
-   */
-  solutions?: string[];
 };
-export function newGame(opts?: NewGameParams): GameState {
-  const numBoards = opts?.numBoards || opts?.solutions?.length || 1;
-  const numGuesses = opts?.numGuesses || numBoards + 5;
+export function newGame({ solutions, numGuesses }: NewGameParams): GameState {
   return {
-    numGuessesAllowed: numGuesses,
+    numGuessesAllowed: numGuesses || solutions.length + 5,
     status: "guessing",
-    gameBoards: Array.from({ length: numBoards }).map((_, i) => ({
+    gameBoards: solutions.map((solution) => ({
       guessedRows: [],
-      solution: opts?.solutions?.[i]?.toUpperCase() ?? pickSolution(),
+      solution: solution.toUpperCase(),
       boardStatus: "in-play",
     })),
     currentRow: "",

--- a/src/state/game-states.ts
+++ b/src/state/game-states.ts
@@ -4,16 +4,21 @@ import { GameState, GuessedRow } from "../types.js";
 type NewGameParams = {
   numBoards?: number;
   numGuesses?: number;
+  /**
+   * Solutions to use, by board index. Boards without one get a random word.
+   * Lets tests pin the answers instead of working around Math.random().
+   */
+  solutions?: string[];
 };
 export function newGame(opts?: NewGameParams): GameState {
-  const numBoards = opts?.numBoards || 1;
+  const numBoards = opts?.numBoards || opts?.solutions?.length || 1;
   const numGuesses = opts?.numGuesses || numBoards + 5;
   return {
     numGuessesAllowed: numGuesses,
     status: "guessing",
-    gameBoards: Array.from({ length: numBoards }).map(() => ({
+    gameBoards: Array.from({ length: numBoards }).map((_, i) => ({
       guessedRows: [],
-      solution: pickSolution(),
+      solution: opts?.solutions?.[i]?.toUpperCase() ?? pickSolution(),
       boardStatus: "in-play",
     })),
     currentRow: "",

--- a/src/state/reducer.test.ts
+++ b/src/state/reducer.test.ts
@@ -1,0 +1,202 @@
+import { describe, it } from "vitest";
+import { KEY_NEW_GAME, KEY_QUIT } from "../constants.js";
+import { expectEqual } from "../test-util.js";
+import { GameAction } from "../ui.js";
+import { GameState } from "../types.js";
+import { newGame } from "./game-states.js";
+import { reducer } from "./reducer.js";
+
+const act = (state: GameState, action: GameAction) => reducer(state, action);
+
+const type = (state: GameState, letters: string) =>
+  [...letters].reduce(
+    (s, letter) => act(s, { action: "input-letter", letter }),
+    state,
+  );
+
+const submit = (state: GameState) => act(state, { action: "submit-guess" });
+const guess = (state: GameState, word: string) => submit(type(state, word));
+const backspace = (state: GameState) => act(state, { action: "backspace" });
+const giveUp = (state: GameState) => act(state, { action: "give-up" });
+
+/** Narrows to the guessing variant, which is the only one with a currentRow. */
+function guessing(state: GameState) {
+  if (state.status != "guessing") {
+    throw new Error(`expected a 'guessing' state, got '${state.status}'`);
+  }
+  return state;
+}
+
+const rowCounts = (state: GameState) =>
+  state.gameBoards.map((b) => b.guessedRows.length);
+
+const colorsOf = (state: GameState, board: number, row: number) =>
+  state.gameBoards[board].guessedRows[row].letters.map((l) => l.color);
+
+describe("reducer", () => {
+  describe("typing", () => {
+    it("appends letters to the current row", () => {
+      const state = type(newGame({ solutions: ["CIGAR"] }), "CIG");
+      expectEqual(guessing(state).currentRow, "CIG");
+    });
+
+    it("ignores letters once the row is full", () => {
+      const full = type(newGame({ solutions: ["CIGAR"] }), "HUMPH");
+      expectEqual(guessing(type(full, "X")).currentRow, "HUMPH");
+    });
+
+    it("removes the last letter on backspace", () => {
+      const state = backspace(type(newGame({ solutions: ["CIGAR"] }), "CIG"));
+      expectEqual(guessing(state).currentRow, "CI");
+    });
+
+    it("ignores backspace on an empty row", () => {
+      const empty = newGame({ solutions: ["CIGAR"] });
+      expectEqual(backspace(empty), empty);
+    });
+  });
+
+  describe("submitting", () => {
+    it("ignores a submission before the row is full", () => {
+      const partial = type(newGame({ solutions: ["CIGAR"] }), "CIG");
+      expectEqual(submit(partial), partial);
+    });
+
+    it("records a valid guess and clears the row", () => {
+      const state = guess(newGame({ solutions: ["CIGAR"] }), "HUMPH");
+      expectEqual(guessing(state).currentRow, "");
+      expectEqual(rowCounts(state), [1]);
+    });
+
+    it("rejects a word that is not in the word list", () => {
+      const state = guess(newGame({ solutions: ["CIGAR"] }), "ZZZZZ");
+      expectEqual(guessing(state).currentRow, "");
+      expectEqual(state.note, "'zzzzz' is not a valid word.");
+      expectEqual(rowCounts(state), [0]);
+    });
+
+    it("clears a stale note once a valid guess lands", () => {
+      const rejected = guess(newGame({ solutions: ["CIGAR"] }), "ZZZZZ");
+      expectEqual(guess(rejected, "HUMPH").note, undefined);
+    });
+
+    // Known bug — see docs/architecture-review.md finding 1.4. The note from a
+    // rejected word survives every later keystroke. Flip to `it` when fixed.
+    it.fails("clears a stale note as soon as the player types again", () => {
+      const rejected = guess(newGame({ solutions: ["CIGAR"] }), "ZZZZZ");
+      expectEqual(type(rejected, "A").note, undefined);
+    });
+  });
+
+  describe("colouring", () => {
+    it("colours a guess against each board's own solution", () => {
+      const state = guess(newGame({ solutions: ["CIGAR", "REBUT"] }), "CIGAR");
+      expectEqual(colorsOf(state, 0, 0), [
+        "green",
+        "green",
+        "green",
+        "green",
+        "green",
+      ]);
+      expectEqual(colorsOf(state, 1, 0), [
+        "gray",
+        "gray",
+        "gray",
+        "gray",
+        "yellow",
+      ]);
+    });
+  });
+
+  describe("winning", () => {
+    it("wins a single-board game on the right word", () => {
+      const state = guess(newGame({ solutions: ["CIGAR"] }), "CIGAR");
+      expectEqual(state.status, "win");
+      expectEqual(state.gameBoards[0].boardStatus, "won");
+    });
+
+    it("wins a two-board game only once both boards are solved", () => {
+      const first = guess(newGame({ solutions: ["CIGAR", "REBUT"] }), "CIGAR");
+      expectEqual(first.status, "guessing");
+      expectEqual(guess(first, "REBUT").status, "win");
+    });
+  });
+
+  describe("losing", () => {
+    it("loses a single-board game once the guesses run out", () => {
+      const first = guess(
+        newGame({ solutions: ["CIGAR"], numGuesses: 2 }),
+        "HUMPH",
+      );
+      expectEqual(first.status, "guessing");
+      expectEqual(guess(first, "SISSY").status, "loss");
+    });
+
+    it("gives up on request", () => {
+      expectEqual(giveUp(newGame({ solutions: ["CIGAR"] })).status, "loss");
+    });
+  });
+
+  describe("multiple boards", () => {
+    it("applies a guess to every board still in play", () => {
+      const state = guess(newGame({ solutions: ["CIGAR", "REBUT"] }), "HUMPH");
+      expectEqual(rowCounts(state), [1, 1]);
+    });
+
+    it("stops adding rows to a board once it is solved", () => {
+      const solved = guess(newGame({ solutions: ["CIGAR", "REBUT"] }), "CIGAR");
+      const state = guess(solved, "HUMPH");
+      expectEqual(rowCounts(state), [1, 2]);
+      expectEqual(state.gameBoards[0].boardStatus, "won");
+    });
+
+    // Known bug — see docs/architecture-review.md finding 1.1. onFinalGuess
+    // counts rows on gameBoards[0], which stops growing once that board is
+    // won, so the game runs past its own limit and the renderer then throws.
+    // Flip to `it` when fixed.
+    it.fails(
+      "ends at the guess limit even when board 0 was solved first",
+      () => {
+        const solved = guess(
+          newGame({ solutions: ["CIGAR", "REBUT"], numGuesses: 3 }),
+          "CIGAR",
+        );
+        const state = guess(guess(solved, "HUMPH"), "SISSY");
+        expectEqual(state.status, "loss");
+      },
+    );
+  });
+
+  describe("after the game ends", () => {
+    const won = guess(
+      newGame({ solutions: ["CIGAR"], numGuesses: 4 }),
+      "CIGAR",
+    );
+
+    it(`'${KEY_NEW_GAME}' starts a fresh game of the same size`, () => {
+      const fresh = act(won, {
+        action: "input-letter",
+        letter: KEY_NEW_GAME,
+      });
+      expectEqual(fresh.status, "guessing");
+      expectEqual(fresh.numGuessesAllowed, 4);
+      expectEqual(rowCounts(fresh), [0]);
+      expectEqual(fresh.exitPlease, undefined);
+    });
+
+    it(`'${KEY_QUIT}' asks the app to exit`, () => {
+      const quit = act(won, { action: "input-letter", letter: KEY_QUIT });
+      expectEqual(quit.exitPlease, true);
+      expectEqual(quit.status, "win");
+    });
+
+    it("ignores any other letter", () => {
+      expectEqual(act(won, { action: "input-letter", letter: "X" }), won);
+    });
+
+    it("ignores further guesses and give-up", () => {
+      expectEqual(submit(won), won);
+      expectEqual(giveUp(won), won);
+    });
+  });
+});

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,5 +1,5 @@
 import { KEY_NEW_GAME, KEY_QUIT, WORD_LEN } from "../constants.js";
-import { colorGuess, isValidWord } from "../game-logic.js";
+import { colorGuess, isValidWord, pickSolutions } from "../game-logic.js";
 import { GameBoardState, GameState } from "../types.js";
 import { GameAction } from "../ui.js";
 import { newGame } from "./game-states.js";
@@ -37,7 +37,7 @@ export function reducer(state: GameState, action: GameAction): GameState {
   } else {
     if (action.action == "input-letter" && action.letter == KEY_NEW_GAME) {
       return newGame({
-        numBoards: state.gameBoards.length,
+        solutions: pickSolutions(state.gameBoards.length),
         numGuesses: state.numGuessesAllowed,
       });
     }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -5,6 +5,7 @@ import { Keyboard } from "./components/keyboard.js";
 import { StatusText } from "./components/status-text.js";
 import { TitleText } from "./components/title-text.js";
 import { deriveGameColors } from "./game-colors.js";
+import { pickSolutions } from "./game-logic.js";
 import { newGame } from "./state/game-states.js";
 import { reducer } from "./state/reducer.js";
 import { GameState } from "./types.js";
@@ -25,9 +26,15 @@ const App: FC<{
 
   const [x, y] = useStdoutDimensions();
 
+  // Lazy init: the initial-state argument is re-evaluated on every render, so
+  // picking the words here rather than inline avoids drawing throwaway
+  // solutions on each keystroke.
   const [gameState, dispatch] = useReducer(
     reducer,
-    initialState ?? newGame({ numBoards, numGuesses }),
+    initialState,
+    (initial) =>
+      initial ??
+      newGame({ solutions: pickSolutions(numBoards ?? 1), numGuesses }),
   );
 
   useEffect(() => {


### PR DESCRIPTION
First of three test-focused PRs. Small refactors + new tests only, all using the existing vitest setup — no new dependencies or tooling.

## `newGame` now requires its solutions

`newGame` takes one solution per board, and the board count derives from the array's length:

```ts
newGame({ solutions: ["CIGAR", "REBUT"], numGuesses: 3 })
```

`game-states.ts` no longer imports `game-logic.ts`, so the state layer is pure data construction with no dependency on the word lists. Randomness moves to the two call sites that actually want it, via a new `pickSolutions(n)` helper. Three call sites changed: `ui.tsx`, the reducer's new-game branch, and `display-rows.test.ts` (which previously depended on a random word — harmless, since it only checks row shapes, but a latent flake).

**This is code organization, not testability.** The reducer's new-game branch still reaches `Math.random()` — explicitly now rather than transitively. Making *that* path deterministic means putting the solutions in the action, which splits the "N only works once the game is over" rule across the reducer and the key handler. Better designed alongside deterministic daily mode, so it's deliberately not here.

While changing the `ui.tsx` call site, `useReducer` switched to its lazy-init form. The initial-state argument is re-evaluated on every render, so picking words inline drew throwaway solutions on every keystroke.

## `src/state/reducer.test.ts`

The reducer is the core state machine and had no coverage at all. Because the bug below needs four actions in sequence to appear, these drive the reducer through action sequences rather than testing it one call at a time:

```ts
const guess = (state: GameState, word: string) => submit(type(state, word));
```

Covered: typing and row-full clamping, backspace bounds, submission before the row is full, valid and invalid words, note lifecycle, per-board colouring, single- and multi-board wins, guess exhaustion, give-up, and the `N`/`Q` keys in terminal states.

## Two known bugs recorded as `it.fails`

Rather than leave these undocumented or turn CI red, they're written as `it.fails`. Vitest reports them as "expected fail", so CI stays green — and each one starts *failing* the moment the bug is fixed, which forces the flip to `it`.

- **Finding 1.1** — a two-board game runs past its guess limit when board 0 is solved first. `onFinalGuess` counts rows on `gameBoards[0]`, which stops growing once that board is won. The renderer then throws `RangeError` on a negative blank-row count.
- **Finding 1.4** — the invalid-word note survives every later keystroke.

Both were confirmed to fail for the intended reason, not incidentally.

## Checks

`yarn build`, `yarn lint`, `yarn prettier --check .` and the `--test midgame --quit` smoke run all pass. Tests go from 11 to 30 passing plus 2 expected failures.

Since the smoke run takes the `initialState` path and never touches `newGame`, the real path was verified separately: board counts, the `numGuesses` default (1→6, 2→7, 3→8, unchanged), the `--num-guesses` override, lowercase normalization, and the reducer's `N` path all behave as before.

Note that `newGame({ solutions: [] })` still yields zero boards and crashes on the first render — finding 1.3, unchanged and simply relocated by this PR.

Next up, as separate PRs: invariant tests for `colorGuess` and the reducer, then extracting `keyToAction` and the CLI flag handling into pure functions so they can be tested directly.